### PR TITLE
continue pipeline in case of exception

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -65,24 +65,6 @@ rule fastqc:
         mv {params.outdir}/{params.rev_outfile} {output.rev}
         """
 
-# rule fastqc:
-#     input:
-#         get_forward
-#     output:
-#         html=output_dir+"/fastqc/{sample}.html",
-#         zip=output_dir+"/fastqc/{sample}_fastqc.zip" # the suffix _fastqc.zip is necessary for multiqc to find the file. If not using multiqc, you are free to choose an arbitrary filename
-#     params:
-#         extra = "--quiet"
-#     log:
-#         "logs/fastqc/{sample}.log"
-#     threads: 1
-#     resources:
-#         mem_mb = 1024
-#     wrapper:
-#         "v2.1.1/bio/fastqc"
-
-# convert fastq to fasta
-# add option for forward and reverse primers if known
 rule fastp:
     input:
         fwd = get_forward,
@@ -249,7 +231,7 @@ rule minimap:
         OUT=$(echo {output_dir}/minimap/{wildcards.sample}.bam)
         if [ -e $FAS ]; then
             echo Running minimap for {wildcards.sample} > {log}
-            minimap2 -ax sr $FAS {input.fwd} {input.rev} 2> {log} | samtools sort -O BAM -o $OUT - 2>> {log}
+            minimap2 -ax sr $FAS {input.fwd} {input.rev} 2> {log} | samtools view -b -F 4 | samtools sort -O BAM -o $OUT - 2>> {log}
             samtools index $OUT 2>> {log}
             samtools index -c $OUT 2>> {log}
         else
@@ -562,6 +544,10 @@ rule final_log:
     shell:
         """
         touch {output}
+        rm $(find -path '*{output_dir}*' -name "*.ok")
+        rm $(find -path '*{output_dir}*' -name "*.fq")
+        rm $(find -path '*{output_dir}*' -name "*.fq.gz")
+        rm $(find -path '*{output_dir}*' -name "*.fastq.gz")
         """
 
 

--- a/config/create_sample_list.sh
+++ b/config/create_sample_list.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+# script creates sample_list.csv which should be specified in config.yaml
+# run it in the "config" folder
+
+# accomodates:
+# https://github.com/o-william-white/genome_skimming_pipeline
+
+# assumption: 
+# sequence data and reference genome db are located in "genome_skimming_pipeline"
+# the first 14 characters of the sequence name can be used as ID (eg. RMNH_5117143_1, negativecontro)
+
+# usage: ./create_sample_list.sh $1 $2 $3
+# $1 = path to the folder that contains the R1 and R2 fastq.gz files (raw data)
+# $2 = path to the seed file (reference genome db)
+# $3 = path to the gene file (reference genome db)
+
+# example: ./create_sample_list.sh \
+# /data/dick.groenenberg/genome_skimming_pipeline/154286/raw_sequences \
+# /data/dick.groenenberg/genome_skimming_pipeline/calliphora_db/mitochondrion/seed.fasta \
+# /data/dick.groenenberg/genome_skimming_pipeline/calliphora_db/mitochondrion/gene.fasta
+
+# outfile name
+tempfile=tempfile.txt
+tempfile2=tempfile2.txt
+tempfile3=tempfile3.txt
+outfile=sample_list.csv
+
+# test if temp- and outfiles exist; exit if they do, create them if they don't exit
+if [[ -e "$tempfile" || -e "$tempfile2" || -e "$outfile" ]]; then
+	printf "script terminated:\n tempfile(s) or sample_list.csv already exist\n" && exit 1
+else
+	touch "$tempfile" "$tempfile2" "$outfile"
+fi
+
+# put forward and reverse in tempfile (assuming candidate files are selected by "RMNH" or "negative")
+ls -1 "$1"/*.gz | awk -F"genome_skimming_pipeline/" '{print $2}' | egrep "RMNH|negative" | sed 'N;s/\(.*\)\n\(.*\)/\1,\2/' > "$tempfile"
+
+# add seed and gene dbs (tempfile2)
+seed=$(echo "$2" |  awk -F"genome_skimming_pipeline/" '{print $2}')
+gene=$(echo "$2" |  awk -F"genome_skimming_pipeline/" '{print $2}')
+while read line; do
+    printf "$line,$seed,$gene\n" >> "$tempfile2"
+done < $tempfile
+
+# extract ID (tempfile3)
+awk -F"raw_sequences/" '{print $2}' "$tempfile2"| cut -c 1-14 > "$tempfile3"
+
+# merge tempfile3 and tempfile2
+paste -d"," "$tempfile3" "$tempfile2" > "$outfile"
+
+# add header
+awk -i inplace 'BEGINFILE{print "ID,forward,reverse,seed,gene"}{print}' "$outfile"
+
+# warn if ID (tempfile3) contains duplicates!
+cat "$tempfile3" | sort -n | uniq -c | awk '{if ($1 > 1) print "\nDuplicate ID(s) detected!"; exit 1}'
+cat "$tempfile3" | sort -n | uniq -c | awk '{if ($1 > 1) print $2}'
+
+# remove tempfiles
+rm "$tempfile" "$tempfile2" "$tempfile3"


### PR DESCRIPTION
Hi Ollie, we had an issue where a gene (actually an intron) was annotated in just one sample. For obvious reasons it wasn't possible to create an alignment or use IQtree, but it would be nice if the pipeline didn't stop with an error (rules: alignment-trim, iqtree and plot-tree). To that end, we modified the snakefile (in case of less than two occurences, input is copied to output, which prevents Snakemake job execution failure), but not on your latest version. I think the changes can be merged, but have not tested it. 

As for commit 204d201; shouldn't -**g**5=h be -**b**5=h ?
